### PR TITLE
Fix division of `Measurement` of `unchained` (or similar) units

### DIFF
--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -259,6 +259,9 @@ template assign2(valArg, arg1, arg2, m1, m2: untyped): untyped {.dirty.} =
 proc `*`*[T: FloatLike; U: FloatLike](x: T, m: Measurement[U]): auto =
   assign1(x * m.val, x, m)
 
+proc `*`*[T: FloatLike; U: FloatLike](m: Measurement[U], x: T): auto =
+  assign1(x * m.val, x, m)
+
 proc `*`*[T: FloatLike](m: Measurement[T], x: T): Measurement[T] =
   assign1(m.val * x, x, m)
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -161,12 +161,12 @@ proc procRes[T](res: T, grad: openArray[T], args: openArray[Measurement[T]]): Me
             # calc derivative of G w.r.t. current indep. var.
             let ∂a_∂x = derivative(x, key)
             if ∂a_∂x != T(0): # skip values with 0 partial deriv.
-              ∂G_∂x = ∂G_∂x + (grad[i] * ∂a_∂x).T # convert product back to avoid `unchained` error
+              ∂G_∂x = (∂G_∂x + (grad[i] * ∂a_∂x).T).T # convert product back to avoid `unchained` error
                                                   # technically this is a product after all
           if ∂G_∂x != T(0):
             # add (σ_x•∂G/∂x)² to total uncertainty (squared), but only if deriv != 0
             resder[key] = ∂G_∂x
-            err = err + ((σ_x * ∂G_∂x) * (σ_x * ∂G_∂x)).T # convert product back to avoid `unchained` error
+            err = (err + ((σ_x * ∂G_∂x) * (σ_x * ∂G_∂x)).T).T # convert product back to avoid `unchained` error
   result = initMeasurement[T](res,
                               T(sqrt(err.float)), # convert to float and back to T to satisfy `unchained`
                               resder, 0'u32)


### PR DESCRIPTION
The `procRes` code is a bit messy, due to how the types are generated. As the function is generic, but doesn't know about the types defined in the calling code, the code sees "new" types generated by the math. As the units are different for the division case, we need even more conversions to the same type `T`.