### PR TITLE
Fixes issues #6, #7 by extending power, misc fixes

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,16 @@
+* v0.2.2
+- export ~to~ procedure (used to convert inner type of a
+  ~Measurement~)
+- fix ~**~, ~^~ for two Measurements
+- allow to disable printing of unicode symbols for string repr of
+  ~Measurement~ by compiling with ~-d:noUnicode~
+- fix issue #6 to allow ~measurement~ procedure to construct correct
+  type for given types other than ~float~
+- fix division of a literal with a measurement
+- fix power math operation for different argument types, including
+  fixing issue #7
+  - adds a new private submodule for a helper macro to generate
+    `power` calls for static integers (including negative)
 * v0.2.1
 - change import path in test file to relative import
 * v0.2.0

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -355,8 +355,7 @@ proc `^`*[T: FloatLike](m: Measurement[T], p: static SomeInteger): auto =
 
 ## -> for RT natural exponents
 proc `**`*[T: FloatLikeSupportsIntegerPowRT](m: Measurement[T], p: SomeInteger): Measurement[T] =
-  result = procRes(m.val ^ p, p.float * power(m.val, (p - 1)), m)
-
+  result = procRes(power(m.val, p), p.float * power(m.val, (p - 1)), m)
 proc `^`*[T: FloatLikeSupportsIntegerPowRT](m: Measurement[T], p: SomeInteger): Measurement[T] =
   m ** p
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -108,7 +108,7 @@ proc procRes[T](res: T, grad: T, arg: Measurement[T]): Measurement[T] =
       der[key] = (grad * val).T # force to `T` to avoid `unchained` errors
   # σ is 0 if input's σ is zero, else it's ∂(f(x))/∂x * Δx =^= grad * arg.uncer
   let σ = if arg.uncer == T(0.0): T(0.0) else: abs((grad * arg.uncer).T) # force to `T` to avoid `unchained` errors
-  result = initMeasurement[T](res, σ, der, 0'u32)
+  result = initMeasurement[T](res, σ, der, 0'u64)
 
 proc derivative[T](a: Measurement[T], key: DerivKey[T]): T =
   result = if key in a.der: a.der[key] else: T(0.0)
@@ -138,7 +138,7 @@ when false:
               # add (σ_x•∂G/∂x)² to total uncertainty (squared), but only if deriv != 0
               resder[key] = ∂G_∂x
               err = err + ((σ_x * ∂G_∂x) * (σ_x * ∂G_∂x)) # convert product back to avoid `unchained` error
-    result = initMeasurement[T](res, sqrt(err), resder, 0'u32)
+    result = initMeasurement[T](res, sqrt(err), resder, 0'u64)
 
 proc procRes[T](res: T, grad: openArray[T], args: openArray[Measurement[T]]): Measurement[T] =
   ## Note: In the body of this we perform rather funny back and forth conversions between `T`
@@ -169,7 +169,7 @@ proc procRes[T](res: T, grad: openArray[T], args: openArray[Measurement[T]]): Me
             err = (err + ((σ_x * ∂G_∂x) * (σ_x * ∂G_∂x)).T).T # convert product back to avoid `unchained` error
   result = initMeasurement[T](res,
                               T(sqrt(err.float)), # convert to float and back to T to satisfy `unchained`
-                              resder, 0'u32)
+                              resder, 0'u64)
 
 proc `±`*[T: FloatLike](val, uncer: T): Measurement[T] =
   result = initMeasurement[T](val, uncer)

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -368,11 +368,12 @@ proc `^`*[T: FloatLike](a, b: Measurement[T]): Measurement[T] = a ** b
 
 import std / macros
 template genCall(fn, letStmt, x, m, deriv: untyped): untyped =
-  proc `fn`*[T](m: Measurement[T]): Measurement[T] =
+  proc `fn`*[T](m: Measurement[T]): auto =
     ## letStmt contains the definition of x, `let x = m.val`
     letStmt
     ## `deriv` is handed as an expression containing `x`
-    result = procRes(fn(x), deriv, m)
+    type U = typeof(fn(x))
+    result = procRes(fn(x), deriv, m.to(U))
 
 macro defineSupportedFunctions(body: untyped): untyped =
   result = newStmtList()

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -179,7 +179,10 @@ proc `±`*[T: FloatLike](val, uncer: T{lit}): Measurement[float] =
   result = initMeasurement[float](val.float, uncer.float)
 
 proc measurement*[T: FloatLike](value, uncertainty: T): Measurement[T] =
-  result = initMeasurement[float](value, uncertainty)
+  result = initMeasurement[T](value, uncertainty)
+
+proc measurement*[T: FloatLike](val, uncer: T{lit}): Measurement[float] =
+  result = initMeasurement[float](val.float, uncer.float)
 
 proc pretty*[T: FloatLike](m: Measurement[T], precision: int): string =
   let mval = m.val.float.formatBiggestFloat(precision = precision)

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -327,8 +327,11 @@ proc `/`*[T: FloatLike; U: FloatLike](m: Measurement[T], x: U): auto =
   assign1(m.val / x, 1.0 / x, m)
 
 ## Overloads for literals that force same type as Measurement has
-proc `/`*[T: FloatLike; U: FloatLike](x: T{lit}, m: Measurement[U]): Measurement[U] =
-  result = procRes(U(U(x) / m.val), U(-x) / (m.val * m.val), m)
+proc `/`*[T: FloatLike; U: FloatLike](x: T{lit}, m: Measurement[U]): auto =
+  type A = typeof( x / m.val )
+  let arg: A = A(x / m.val)
+  let grad: A =  A(-x / (m.val * m.val))
+  result = procRes(arg, grad, m.to(A))
 proc `/`*[U: FloatLike; T: FloatLike](m: Measurement[U], x: T{lit}): Measurement[U] =
   result = procRes(U(m.val / U(x)), 1.0 / U(x), m)
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -184,7 +184,10 @@ proc measurement*[T: FloatLike](value, uncertainty: T): Measurement[T] =
 proc pretty*[T: FloatLike](m: Measurement[T], precision: int): string =
   let mval = m.val.float.formatBiggestFloat(precision = precision)
   let merr = m.uncer.float.formatBiggestFloat(precision = precision)
-  result = &"{mval} ± {merr}"
+  when not defined(noUnicode):
+    result = &"{mval} ± {merr}"
+  else:
+    result = &"{mval} +- {merr}"
   when not (T is float):
     result.add " " & $T
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -24,6 +24,11 @@ type
 
   Derivatives[T] = OrderedTable[DerivKey[T], T]
 
+  ## *NOTE*: When dealing with `unchained` units, the derivative returned has the
+  ## wrong units! Instead of `T` it should be the type of `∂a(x)/∂x`, but
+  ## the code gets too complicated for the time being, as it would require use to
+  ## store different types for the actual measurement and the gradient, turning
+  ## `Measurement` into a double generic.
   Measurement*[T: FloatLike] = object
     val: T
     uncer: T
@@ -111,6 +116,7 @@ proc procRes[T](res: T, grad: T, arg: Measurement[T]): Measurement[T] =
   result = initMeasurement[T](res, σ, der, 0'u64)
 
 proc derivative[T](a: Measurement[T], key: DerivKey[T]): T =
+  ## See note about derivative in definition of `Measurement` type
   result = if key in a.der: a.der[key] else: T(0.0)
 
 ## A "type safe" solution required for `unchained` could be achieved with something like this.

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -18,6 +18,26 @@ type
   FloatLike* = concept x
     x.toFloat is float
 
+  ## A concept for any float like that is *not* an integer type
+  FloatLikeNotInt* = concept x, type T
+    x.toFloat is float
+    not (T is SomeInteger)
+
+  ## A concept for types that are float like and whose application of
+  ## `pow` compiles and yields the same type. E.g. `float32`, but not
+  ## an `unchained` unit (does not support `pow`)
+  FloatLikeSupportsPow* = concept x, type T
+    x.toFloat is float
+    pow(x, 1.0) is T
+
+  ## A concept for types that are float like and whose application of
+  ## `^` with a RT integer value compiles and yields the same type. E.g. `float32`,
+  ## but not an `unchained` unit (needs a `static int` to know the resulting
+  ## type at CT)
+  FloatLikeSupportsIntegerPowRT* {.explain.} = concept x, type T
+    x.toFloat is float
+    (x ^ 1) is T
+
   IdType = uint64 # "`uint64` should be enough for everyone... uhhh"
 
   DerivKey[T] = tuple[val, uncer: T, tag: IdType]
@@ -242,7 +262,7 @@ proc `-=`*[T: FloatLike](a: var Measurement[T], b: Measurement[T]) =
 
 
 ## Type conversion. TODO: make this more type safe, funnily enough
-proc to[T: FloatLike; U](m: Measurement[T], dtype: typedesc[U]): Measurement[U] =
+proc to*[T: FloatLike; U](m: Measurement[T], dtype: typedesc[U]): Measurement[U] =
   when T is U:
     result = m
   else:

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -34,7 +34,7 @@ type
   ## `^` with a RT integer value compiles and yields the same type. E.g. `float32`,
   ## but not an `unchained` unit (needs a `static int` to know the resulting
   ## type at CT)
-  FloatLikeSupportsIntegerPowRT* {.explain.} = concept x, type T
+  FloatLikeSupportsIntegerPowRT* = concept x, type T
     x.toFloat is float
     (x ^ 1) is T
 
@@ -49,11 +49,21 @@ type
   ## the code gets too complicated for the time being, as it would require use to
   ## store different types for the actual measurement and the gradient, turning
   ## `Measurement` into a double generic.
-  Measurement*[T: FloatLike] = object
-    val: T
-    uncer: T
-    id: IdType
-    der: Derivatives[T] # map of the derivatives
+when (NimMajor, NimMinor, NimPatch) < (1, 7, 0):
+  type
+    Measurement*[T] = object
+      val: T
+      uncer: T
+      id: IdType
+      der: Derivatives[T] # map of the derivatives
+else:
+  type
+    Measurement*[T: FloatLike] = object
+      val: T
+      uncer: T
+      id: IdType
+      der: Derivatives[T] # map of the derivatives
+
 
 func value*[T: FloatLike](m: Measurement[T]): T {.inline.} = m.val
 func uncertainty*[T: FloatLike](m: Measurement[T]): T {.inline.} = m.uncer

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -75,7 +75,11 @@ proc `==`*[T: FloatLike](k1, k2: DerivKey[T]): bool =
 ## value and uncertainty.
 ## TODO: should we use `almostEqual` here? Or is that too imprecise for the purpose?
 proc `==`*[T: FloatLike](m1, m2: Measurement[T]): bool =
-  result = almostEqual(m1.val, m2.val) and almostEqual(m1.uncer, m2.uncer)
+  ## comparison of two measurements does not need to take into account the
+  ## type, as we require same type anyway. Hence use `toFloat` to compare as float
+  bind toFloat # bind the locally defined `toFloat`
+  result = almostEqual(m1.val.toFloat, m2.val.toFloat) and
+           almostEqual(m1.uncer.toFloat, m2.uncer.toFloat)
 
 proc `==`*[T: FloatLike](m: Measurement[T], x: T): bool =
   result = almostEqual(m.val, x) and m.uncer == 0.0
@@ -87,6 +91,7 @@ proc isInf*[T: FloatLike](m: Measurement[T]): bool = m.val == Inf
 proc isNegInf*[T: FloatLike](m: Measurement[T]): bool = m.val == -Inf
 
 proc toFloat*[T: SomeFloat](x: T): float = x.float # float is biggest type, so this should be fine
+proc toFloat*[T: SomeInteger](x: T): float = x.float # float is biggest type, so this should be fine
 
 proc initDerivatives[T](): Derivatives[T] = initOrderedTable[DerivKey[T], T]()
 

--- a/measuremancer/math_utils.nim
+++ b/measuremancer/math_utils.nim
@@ -1,0 +1,43 @@
+import std / macros
+
+# Taken from `unchained`. This won't be exported from `measuremancer` though,
+# rather we will `bind` in the scope in which we use this.
+macro power*(x: typed, num: static int): untyped =
+  ## general purpose power using `^` for integers, which works for any
+  ## type by rewriting to a product of `*`.
+  ##
+  ## For the special cases of -1, 0, 1 we simply rewrite to the correct
+  ## result. Negative powers are written as `1 / x^p`
+  if num == 0:
+    result = quote do:
+      `x` * typeof(`x`)(0.0)
+  elif num == 1:
+    result = x
+  elif num == -1:
+    ## Assume that the type supports addition by a float!
+    result = quote do:
+      1.0 / `x`
+  else:
+    result = nnkInfix.newTree(ident"*")
+
+    proc addInfix(n, x: NimNode, num: int) =
+      var it = n
+      if num > 0:
+        it.add nnkInfix.newTree(ident"*")
+        it[1].addInfix(x, num - 1)
+      while it.len < 3:
+        it.add x
+
+    result.addInfix(x, abs(num) - 2)
+
+    # invert if num is negative
+    if num < -1:
+      ## Assume that the type supports addition by a float!
+      result = quote do:
+        1.0 / (`result`)
+
+import std/math
+proc power*[T](x: T, num: SomeInteger): T =
+  if num > 0: result = x ^ num
+  elif num == 0: result = T(1)
+  else: result = T(1) / (x ^ abs(num))

--- a/measuremancer/math_utils.nim
+++ b/measuremancer/math_utils.nim
@@ -10,7 +10,7 @@ macro power*(x: typed, num: static int): untyped =
   ## result. Negative powers are written as `1 / x^p`
   if num == 0:
     result = quote do:
-      `x` * typeof(`x`)(0.0)
+      1.0
   elif num == 1:
     result = x
   elif num == -1:

--- a/tests/tmeasuremancer.nim
+++ b/tests/tmeasuremancer.nim
@@ -138,6 +138,13 @@ suite "Measurements of other types (e.g. unchained)":
     check( (k1 + k2).value.type is keV )
     check( (k1 + k2).error.type is keV )
 
+  test "Construction of `measurement` via proc":
+    let k1 = measurement(5.0.keV, 1.0.keV)
+    let k2 = measurement(2.5.keV, 1.5.keV)
+    check k1 + k2 =~= 7.5.keV ± 1.802775637731995.keV
+    check( (k1 + k2).value.type is keV )
+    check( (k1 + k2).error.type is keV )
+
   test "Addition of incompatible units fails":
     let k1 = 5.0.keV ± 1.0.keV
     let m = 1.0.kg ± 0.1.kg


### PR DESCRIPTION
Mainly fixes #6 and #7 by improving the handling of how the power operation is implemented. Now also includes a submodule for static integer power, so that `unchained` powers are supported as long as the power is static (as we need to be able to compute the type at CT!).

Further fixes a few small miscellaneous things. Full changelog below.

```
* v0.2.2
- export ~to~ procedure (used to convert inner type of a
  ~Measurement~)
- fix ~**~, ~^~ for two Measurements
- allow to disable printing of unicode symbols for string repr of
  ~Measurement~ by compiling with ~-d:noUnicode~
- fix issue #6 to allow ~measurement~ procedure to construct correct
  type for given types other than ~float~
- fix division of a literal with a measurement
- fix power math operation for different argument types, including
  fixing issue #7
  - adds a new private submodule for a helper macro to generate
    `power` calls for static integers (including negative)
```