### PR TITLE
fix division of int literal with `Measurement`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.2.3
+- fix regression that disabled ability to use division of int literals
+  with a ~Measurement~
 * v0.2.2
 - export ~to~ procedure (used to convert inner type of a
   ~Measurement~)

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -338,12 +338,16 @@ proc `/`*[T: FloatLike; U: FloatLike](m: Measurement[T], x: U): auto =
 
 ## Overloads for literals that force same type as Measurement has
 proc `/`*[T: FloatLike; U: FloatLike](x: T{lit}, m: Measurement[U]): auto =
+  when T is SomeInteger:
+    let x = U(x)
   type A = typeof( x / m.val )
   let arg: A = A(x / m.val)
   let grad: A =  A(-x / (m.val * m.val))
   result = procRes(arg, grad, m.to(A))
 proc `/`*[U: FloatLike; T: FloatLike](m: Measurement[U], x: T{lit}): Measurement[U] =
-  result = procRes(U(m.val / U(x)), 1.0 / U(x), m)
+  when T is SomeInteger:
+    let x = U(x)
+  result = procRes(U(m.val / x), 1.0 / x, m)
 
 # Power `^`
 ## NOTE: Using any of the following exponentiation functions is dangerous. The Nim parser

--- a/tests/tmeasuremancer.nim
+++ b/tests/tmeasuremancer.nim
@@ -31,6 +31,12 @@ suite "Measurement & constant":
     check x / y == 1.0 ± 0.1
     check y / x == 1.0 ± 0.1
 
+  test "Division by int literal / const with Measurement":
+    let x = 5.0 ± 0.5
+    const y = 5
+    check x / y == 1.0 ± 0.1
+    check y / x == 1.0 ± 0.1
+
 suite "Measurement & measurement":
   test "Addition":
     let x = 1.0 ± 0.1


### PR DESCRIPTION
Broke this on the last release, which itself broke numericalnim's CI.