### PR TITLE
Export fields so that client code can customize `$` output.

### DIFF
--- a/README.org
+++ b/README.org
@@ -128,6 +128,7 @@ avoid having to set this setting manually every time.
  allowed by default.  So, special compilation options are unneeded.
 
 If compiled with `-d:useCligen`, uncertain number pair formatting is the
-default `cligen/strUt.fmtUncertain`.  That uses the uncertainty to limit
-precision of both value & uncertainty to the same decimal place (2 decimals
-of the uncertainty by default, as per one common convention).
+default [`cligen/strUt`](https://github.com/c-blake/cligen/blob/master/cligen/strUt.nim).`fmtUncertain`
+That uses the uncertainty to limit precision of both value & uncertainty to the
+same decimal place (2 decimals of the uncertainty by default, as per one common
+convention).

--- a/README.org
+++ b/README.org
@@ -110,7 +110,7 @@ still a chance of things breaking. Basic math (=*=, =/=, =+= and =-=)
 should work correctly now though.
 
 
-** Compilation flags & Nim versions prior to 1.6
+** Compilation flags & Nim version notes
 
 As of Nim version 1.6 any code using this library has to be compiled
 with:
@@ -124,4 +124,10 @@ avoid having to set this setting manually every time.
 *NOTE*: This flag was not available in Nim 1.4 yet. Unicode operators
  simply weren't a thing. If you wish to use this library anyway, you
  can do so, simply by constructing =Measurements= using the
- =measurement= procedure.
+ =measurement= procedure.  Further, in Nim >= 2.0, unicode operators are
+ allowed by default.  So, special compilation options are unneeded.
+
+If compiled with `-d:useCligen`, uncertain number pair formatting is the
+default `cligen/strUt.fmtUncertain`.  That uses the uncertainty to limit
+precision of both value & uncertainty to the same decimal place (2 decimals
+of the uncertainty by default, as per one common convention).

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -229,15 +229,21 @@ proc measurement*[T: FloatLike](value, uncertainty: T): Measurement[T] =
 proc measurement*[T: FloatLike](val, uncer: T{lit}): Measurement[float] =
   result = initMeasurement[float](val.float, uncer.float)
 
-proc pretty*[T: FloatLike](m: Measurement[T], precision: int): string =
-  let mval = m.val.float.formatBiggestFloat(precision = precision)
-  let merr = m.uncer.float.formatBiggestFloat(precision = precision)
-  when not defined(noUnicode):
-    result = &"{mval} ± {merr}"
-  else:
-    result = &"{mval} +- {merr}"
-  when not (T is float):
-    result.add " " & $T
+when defined(useCligen):
+  import cligen/strUt
+  proc pretty*[T: FloatLike](m: Measurement[T], precision: int): string =
+    result = fmtUncertain(m.val.float, m.uncer.float)
+    when not (T is float): result.add " " & $T
+else:
+  proc pretty*[T: FloatLike](m: Measurement[T], precision: int): string =
+    let mval = m.val.float.formatBiggestFloat(precision = precision)
+    let merr = m.uncer.float.formatBiggestFloat(precision = precision)
+    when not defined(noUnicode):
+      result = &"{mval} ± {merr}"
+    else:
+      result = &"{mval} +- {merr}"
+    when not (T is float):
+      result.add " " & $T
 
 proc `$`*[T: FloatLike](m: Measurement[T]): string = pretty(m, 3)
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -215,6 +215,10 @@ proc procRes[T](res: T, grad: openArray[T], args: openArray[Measurement[T]]): Me
 proc `±`*[T: FloatLike](val, uncer: T): Measurement[T] =
   result = initMeasurement[T](val, uncer)
 
+proc `+-`*[T: FloatLike](val, uncer: T): Measurement[T] = val ± uncer
+  ## `noUnicode`-mode makes output like this which users may want to re-use as
+  ## input without edit.  Nim 2/`--experimental:unicodeOperators` allows it.
+
 ## Do we want the following? It forces any `FloatLike` to generate a `Measurement[float]`!
 proc `±`*[T: FloatLike](val, uncer: T{lit}): Measurement[float] =
   result = initMeasurement[float](val.float, uncer.float)

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -59,8 +59,8 @@ when (NimMajor, NimMinor, NimPatch) < (1, 7, 0):
 else:
   type
     Measurement*[T: FloatLike] = object
-      val: T
-      uncer: T
+      val*: T
+      uncer*: T
       id: IdType
       der: Derivatives[T] # map of the derivatives
 


### PR DESCRIPTION
This lets one do, for example, a simple script wrapper:
```sh
#!/bin/sh
: "${NR:=nim r}" # alias a='noglob THIS' => a (4.65+-0.01)*(4.650+-0.009) works
: "${NO:=--verbosity:0 --hints:off --warnings:off}"
(printf '%s\n' \
  'import measuremancer, std/[math, lenientops], cligen/strUt' \
  'converter f(x: SomeInteger): float = x.float' \
  'proc `^`[A, B](x: A, y: B): float = exp(x.float.ln * y.float)' \
  'proc `+-`[T: FloatLike](val,uncer: T): Measurement[T] = val ± uncer' \
  'proc `$`[T: FloatLike](m: Measurement[T]): string =' \
  '  result = fmtUncertain(m.val.float, m.uncer.float)' \
  '  when T isnot float: result.add " " & $T'
 printf '%s' 'echo ' "$@" ) | $NR $NO -
```
that then uses the uncertainty-driven precision formatting engine of `cligen/strUt.fmtUncertain`.