### PR TITLE
Improve `unchained` interop

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,11 @@
+* v0.2.8
+- add equality of Measurements with "different" types (if aliases)
+- improve concept definition, add ~to~ for numbers
+- fix ~^~, ~**~ involving a ~UnitLess~ and regular ~float~, due to the
+  ~distinct~ nature of the former relative to the latter
+- force Nim 1.6 Measurement type to require ~FloatLike~
+- fix division involving integer literals
+- add some more ~unchained~ related tests
 * v0.2.7
 - fix import of ~measuremancer~ in ~tCligenParsing~ to use local path
 * v0.2.6

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -66,8 +66,8 @@ type
 when (NimMajor, NimMinor, NimPatch) < (1, 7, 0):
   type
     Measurement*[T: FloatLike] = object
-      val: T
-      uncer: T
+      val*: T
+      uncer*: T
       id: IdType
       der: Derivatives[T] # map of the derivatives
 else:

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -132,6 +132,16 @@ proc `==`*[T: FloatLike](m1, m2: Measurement[T]): bool =
   result = almostEqual(m1.val.toFloat, m2.val.toFloat) and
            almostEqual(m1.uncer.toFloat, m2.uncer.toFloat)
 
+proc to*[T: FloatLike; U](m: Measurement[T], dtype: typedesc[U]): Measurement[U]
+proc `==`*[T: FloatLike; U: FloatLike](m1: Measurement[T], m2: Measurement[U]): bool =
+  ## NOTE: This is a bit hacky, but it checks if two types are simply aliases based
+  ## on their names being equal. In `unchained` this can happen if a local type
+  ## is redefined and the two measurements have different "type instances".
+  when $T == $U:
+    result = m1 == m2.to(T)
+  else:
+    {.error: "Cannot compare measurements with type: " & $T & " to a measurement with type " & $U.}
+
 proc `==`*[T: FloatLike](m: Measurement[T], x: T): bool =
   result = almostEqual(m.val, x) and m.uncer == 0.0
 

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -375,21 +375,20 @@ proc `/`*[T: FloatLike; U: FloatLike](m: Measurement[T], x: U): auto =
 ## Overloads for literals that force same type as Measurement has
 proc `/`*[T: FloatLike; U: FloatLike](x: T{lit}, m: Measurement[U]): auto =
   when T is SomeInteger:
-    let x = U(x)
+    let x = x.float
   type A = typeof( x / m.val )
   let arg: A = A(x / m.val)
   let grad: A =  A(-x / (m.val * m.val))
   result = procRes(arg, grad, m.toInternal(A))
 proc `/`*[U: FloatLike; T: FloatLike](m: Measurement[U], x: T{lit}): Measurement[U] =
   when T is SomeInteger:
-    let x = U(x)
-  result = procRes(U(m.val / x), 1.0 / x, m)
+    let x = x.float
+  result = procRes(m.val / x, U(1.0 / x), m)
 
 # Power `^`
 ## NOTE: Using any of the following exponentiation functions is dangerous. The Nim parser
 ## might include an additional prefix into the argument to `^` instead of keeping it as a,
 ## well, prefix. So `-(x - μ)^2` is parsed as `(-(x - μ))^2`!
-
 from measuremancer / math_utils import power
 ## -> for static exponents
 proc `**`*[T: FloatLike](m: Measurement[T], p: static SomeInteger): auto =

--- a/measuremancer.nim
+++ b/measuremancer.nim
@@ -52,7 +52,7 @@ type
   ## `Measurement` into a double generic.
 when (NimMajor, NimMinor, NimPatch) < (1, 7, 0):
   type
-    Measurement*[T] = object
+    Measurement*[T: FloatLike] = object
       val: T
       uncer: T
       id: IdType


### PR DESCRIPTION
Fixes a few issues when working on Unchained types. 

*IMPORTANT*: You need to update to Unchained version `v0.4.2`, which I just tagged.

```
* v0.2.8
- add equality of Measurements with "different" types (if aliases)
- improve concept definition, add ~to~ for numbers
- fix ~^~, ~**~ involving a ~UnitLess~ and regular ~float~, due to the
  ~distinct~ nature of the former relative to the latter
- force Nim 1.6 Measurement type to require ~FloatLike~
- fix division involving integer literals
- add some more ~unchained~ related tests
```